### PR TITLE
Fix missing hostname for final "Finished"

### DIFF
--- a/ccollect
+++ b/ccollect
@@ -561,4 +561,4 @@ if [ -x "${CPOSTEXEC}" ]; then
 fi
 
 rm -f "${TMP}"
-_techo "Finished"
+_techo "Finished" | add_name


### PR DESCRIPTION
Final "Finished" message for a backup run is missing the hostname. This is not useful for parallel runs where one might want to correlate end times to jobs.

FFTTMTFO ;)